### PR TITLE
bugfix: buffer overflow exceptions because of 'z' compression

### DIFF
--- a/src/main/java/com/github/fzakaria/ascii85/Ascii85.java
+++ b/src/main/java/com/github/fzakaria/ascii85/Ascii85.java
@@ -91,10 +91,21 @@ public class Ascii85 {
         if (chars == null || chars.length() == 0) {
             throw new IllegalArgumentException("You must provide a non-zero length input");
         }
-        //By using five ASCII characters to represent four bytes of binary data the encoded size ¹⁄₄ is larger than the original
-        BigDecimal decodedLength = BigDecimal.valueOf(chars.length()).multiply(BigDecimal.valueOf(4))
-                .divide(BigDecimal.valueOf(5));
-        ByteBuffer bytebuff = ByteBuffer.allocate(decodedLength.intValue());
+        // Because we perform compression when encoding four bytes of zeros to a single 'z', we need
+        // to scan through the input to compute the target length, instead of just subtracting 20% of
+        // the encoded text length.
+        final int inputLength = chars.length();
+        int computedLength = 0;
+        for (int idx = 0; idx < inputLength; ++idx) {
+            if (chars.charAt(idx) != 'z') {
+                for (int c = 0; c < 5 && idx < inputLength; ++idx, ++c) {
+                    if (c > 0) ++computedLength;
+                }
+                --idx;
+            }
+            else computedLength += 4;
+        }
+        ByteBuffer bytebuff = ByteBuffer.allocate(computedLength);
         //1. Whitespace characters may occur anywhere to accommodate line length limitations. So lets strip it.
         chars = REMOVE_WHITESPACE.matcher(chars).replaceAll("");
         //Since Base85 is an ascii encoder, we don't need to get the bytes as UTF-8.

--- a/src/test/java/com/github/fzakaria/ascii85/Ascii85Test.java
+++ b/src/test/java/com/github/fzakaria/ascii85/Ascii85Test.java
@@ -105,4 +105,25 @@ public class Ascii85Test {
         assertNotNull(Ascii85.decode(encodedString));
     }
 
+    @Test
+    public void testZeroStringDecodes() {
+        testZeroStringDecode(530);
+        testZeroStringDecode(531);
+        testZeroStringDecode(532);
+        testZeroStringDecode(533);
+        testZeroStringDecode(534);
+    }
+
+    public void testZeroStringDecode(int length) {
+        byte[] data = new byte[length];
+        for (int c = 0; c < length; c++) data[c] = 0;
+        try {
+            String encoded = Ascii85.encode(data);
+            byte[] decoded = Ascii85.decode(encoded);
+            assertEquals(length, decoded.length);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert(false);
+        }
+    }
 }


### PR DESCRIPTION
include compression factor when allocating decoding buffer, to avoid buffer overflows